### PR TITLE
Fix missing images

### DIFF
--- a/image-slider.js
+++ b/image-slider.js
@@ -28,6 +28,11 @@ H5P.ImageSlider = (function ($) {
       }
     }, options);
 
+    // Filter out slides without image
+    this.options.imageSlides = this.options.imageSlides.filter(function (slide) {
+      return slide.params && slide.params.image && slide.params.image.params && slide.params.image.params.file;
+    });
+
     // Keep provided id.
     this.id = id;
     this.currentSlideId = 0;


### PR DESCRIPTION
Currently, the content type crashes if you add a slide without an image. When merged in, this will be fixed by filtering out slides without an image.