### PR TITLE
fix / Ensure one nav button remains focus when navigating with them

### DIFF
--- a/image-slider.js
+++ b/image-slider.js
@@ -243,12 +243,14 @@ H5P.ImageSlider = (function ($) {
     C.handleButtonClick(this.$leftButton, function () {
       if (!self.dragging) {
         self.gotoSlide(self.currentSlideId - 1);
+        self.ensureNavButtonFocus(self.$leftButton);
       }
     });
 
     C.handleButtonClick(this.$rightButton, function() {
       if (!self.dragging) {
         self.gotoSlide(self.currentSlideId + 1);
+        self.ensureNavButtonFocus(self.$rightButton);
       }
     });
 
@@ -418,6 +420,21 @@ H5P.ImageSlider = (function ($) {
     }
     this.$leftButton.css('height', heightInPercent + '%');
     this.$rightButton.css('height', heightInPercent + '%');
+  };
+
+  /**
+   * Ensure that one of the navigation buttons remains focus.
+   * @param {jQuery} $button Calling button.
+   */
+  C.prototype.ensureNavButtonFocus = function($button) {
+    if (!$button) {
+      return;
+    }
+
+    const $antagonist = ($button === this.$leftButton) ? this.$rightButton : this.$leftButton;
+    if ($button.is(':hidden') && $antagonist.is(':visible')) {
+      $antagonist.get(0).querySelector('[role="button"]').focus();
+    }
   };
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
DOM element focus is lost when navigating to the first/last slide using the navigation buttons. Cmp. https://github.com/h5p/h5p-image-slider/issues/57

**What is the new behaviour?**
- When moving to the last slide with the right navigation button and that button gets hidden, the left navigation button receives focus.
- When moving to the first slide with the left navigation button and that button gets hidden, the right navigation button receives focus.
Fixes https://github.com/h5p/h5p-image-slider/issues/57

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
